### PR TITLE
Fix Linux build issues on Ubuntu 22.04

### DIFF
--- a/consts.h
+++ b/consts.h
@@ -133,8 +133,8 @@ extern int	errno;
 #define	EXTERNAL	extern
 #endif
 
-INTERNAL int	MAX_LINES;		/* Dynamic! [mea]		*/
 #ifdef MAIN
+INTERNAL int	MAX_LINES;		/* Dynamic! [mea]		*/
 INTERNAL char	BITNET_QUEUE[80];	/* The BITnet queue directory	*/
 INTERNAL char   COMMAND_MAILBOX[80];	/* The command channel		*/
 INTERNAL char	LOCAL_NAME[10];		/* Our BITnet name (In ASCII)	*/
@@ -156,6 +156,7 @@ INTERNAL char	ClusterNode[16];	/* DECnet name of the cluster's
 					   node conncted with NJE to the
 					   outer world			*/
 #else
+EXTERNAL int	MAX_LINES;		/* Dynamic! [mea]		*/
 EXTERNAL char	BITNET_QUEUE[80];
 EXTERNAL char	COMMAND_MAILBOX[80];
 EXTERNAL char	LOCAL_NAME[10];

--- a/prototypes.h
+++ b/prototypes.h
@@ -72,8 +72,13 @@
 
 /* There are systems with proper library prototypes available, let them
    not to surprise here! */
-
+/* glibc's errno manpage says not to declare errno explicitly and that
+ * it can cause problems if we do */
+#if __GLIBC__ >= 2
+#else
 extern int	errno;
+#endif
+
 #ifdef __DARWIN_UNIX03
 extern const int	sys_nerr;	/* Maximum error number recognised */
 #else

--- a/prototypes.h
+++ b/prototypes.h
@@ -79,10 +79,15 @@ extern const int	sys_nerr;	/* Maximum error number recognised */
 #else
 extern int	sys_nerr;	/* Maximum error number recognised */
 #endif
-
+/* On systems with glibc >= 2.32 sys_nerr and sys_errlist are no longer
+ * exposed. use strerror instead 
+ */
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ >= 32
+#define PRINT_ERRNO (strerror(errno))
+#else
 /* extern char	*sys_errlist[];	*/ /* List of error messages */
 #define	PRINT_ERRNO	(errno > sys_nerr ? "***" : sys_errlist[errno])
-
+#endif
 
 #if	defined(__POSIX_SOURCE) || defined(__POSIX_C_SOURCE) || defined(__svr4__)
 #define GETDTABLESIZE(x) sysconf(_SC_OPEN_MAX)

--- a/unix.c
+++ b/unix.c
@@ -82,8 +82,6 @@ extern const int	sys_nerr;	/* Maximum error number recognised */
 #else
 extern int	sys_nerr;	/* Maximum error number recognised */
 #endif
-/* extern char	*sys_errlist[];	*/ /* List of error messages */
-#define	PRINT_ERRNO	(errno > sys_nerr ? "***" : sys_errlist[errno])
 
 u_int32 socket_access_key;
 

--- a/unix_route.c
+++ b/unix_route.c
@@ -23,8 +23,6 @@ extern const int	sys_nerr;	/* Maximum error number recognised */
 #else
 extern int	sys_nerr;	/* Maximum error number recognised */
 #endif
-/* extern char	*sys_errlist[];	*/ /* List of error messages */
-#define	PRINT_ERRNO	(errno > sys_nerr ? "***" : sys_errlist[errno])
 
 struct Bintree *routedb = NULL;
 

--- a/unix_tcp.c
+++ b/unix_tcp.c
@@ -52,8 +52,6 @@ extern const int	sys_nerr;	/* Maximum error number recognised */
 #else
 extern int	sys_nerr;	/* Maximum error number recognised */
 #endif
-/* extern char	*sys_errlist[];	*/ /* List of error messages */
-#define	PRINT_ERRNO	(errno > sys_nerr ? "***" : sys_errlist[errno])
 
 
 /*  Systems have differing ways to define NON-blocking IO..


### PR DESCRIPTION
- fix problems with glibc >= 2.32
- deal with ld complaining about multiply defined symbol MAX_LINES on Ubuntu 22.04
